### PR TITLE
Fix document formatter indentation and SQL formatting styles

### DIFF
--- a/tests/formatter.test.ts
+++ b/tests/formatter.test.ts
@@ -641,7 +641,8 @@ describe('SSL Formatter - SQL Formatting', () => {
 
 	it('should format SQLExecute inline literals with clause indentation', () => {
 		const input = 'SQLExecute("select col1, col2 from Patients where id = ?sId? and status = ?sStatus?");';
-		const expected = 'SQLExecute("SELECT\n    col1,\n    col2\nFROM Patients WHERE id = ?sId?\n  AND status = ?sStatus?");\n';
+		// Canonical compact: columns on same line, hanging AND
+		const expected = 'SQLExecute("SELECT col1, col2\nFROM Patients\nWHERE id = ?sId?\n  AND status = ?sStatus?");\n';
 
 		const doc = createDocument(input);
 		const edits = formatter.provideDocumentFormattingEdits(doc as any, options, null as any);
@@ -652,7 +653,8 @@ describe('SSL Formatter - SQL Formatting', () => {
 
 	it('should format RunSQL literals and preserve placeholders', () => {
 		const input = 'RunSQL("update Foo set bar = ? where baz = ? or flag = ?", , , { sBar, sBaz, sFlag });';
-		const expected = 'RunSQL("UPDATE Foo SET bar = ? WHERE baz = ?\n  OR flag = ?", ,, { sBar, sBaz, sFlag });\n';
+		// Canonical compact: OR gets 7-space indent for alignment
+		const expected = 'RunSQL("UPDATE Foo SET bar = ?\nWHERE baz = ?\n       OR flag = ?", ,, { sBar, sBaz, sFlag });\n';
 
 		const doc = createDocument(input);
 		const edits = formatter.provideDocumentFormattingEdits(doc as any, options, null as any);
@@ -664,7 +666,8 @@ describe('SSL Formatter - SQL Formatting', () => {
 	it('should respect SQL keyword casing preference', () => {
 		config.update('ssl.format.sql.keywordCase', 'preserve');
 		const input = 'SQLExecute("Select * from Samples where status = ?sStatus?");';
-		const expected = 'SQLExecute("Select\n    *\nfrom Samples where status = ?sStatus?");\n';
+		// Preserve case: keeps original keyword casing
+		const expected = 'SQLExecute("Select *\nfrom Samples\nwhere status = ?sStatus?");\n';
 
 		const doc = createDocument(input);
 		const edits = formatter.provideDocumentFormattingEdits(doc as any, options, null as any);
@@ -909,7 +912,7 @@ describe('SSL Formatter - Style Guide Fixtures', () => {
 
 	// Skip if fixture directory doesn't exist
 	if (!fs.existsSync(fixtureDir)) {
-		it.skip('Fixture directory not found', () => {});
+		it.skip('Fixture directory not found', () => { });
 		return;
 	}
 


### PR DESCRIPTION
## Summary

This PR fixes two issues with the formatter:

### Document Formatter Indentation
When formatting files with multi-line SQL strings (like `QCSAMPLESINSERTIRUN.srvscr`), the indentation would go wild. The root cause was incorrect bracket counting - parentheses inside SQL strings were being counted as code, causing subsequent lines to be massively over-indented.

**Changes:**
- Add `stripAllStringContent()` method to properly handle partial strings
- Fix multi-line string end detection to count brackets appearing after the closing quote
- Lines in the middle of multi-line strings are now properly skipped for bracket counting

### SQL Formatting Styles
The SQL formatting commands (especially Canonical Compact) weren't matching the examples in `sql-formats.md`. 

**Changes:**
- Rewrite `formatCanonicalCompactStyle` to match documented format
- Keep SELECT columns on same line (wrap at 80 chars)
- Add proper WHERE clause line breaks (was getting merged with ON)
- Fix hanging operators: AND at 2-space indent, OR at 7-space alignment

## Testing
- All 198 unit tests pass
- Manually tested on problematic sample files