### PR TITLE
feat: 1.9.0 — universal suppress + show-docs code actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to the "STARLIMS Scripting Language" extension will be docum
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.9.0] - 2026-04-30
+
+### Added
+- **Universal suppression code actions.** Every LSP-emitted diagnostic with
+  a known rule slug now offers two extra lightbulb entries:
+  - *"Suppress 'X' on this line"* — inserts `/* @ssl-disable-next-line X; */`
+    on the line above, indented to match.
+  - *"Suppress 'X' for this file"* — inserts `/* @ssl-disable X; */` at the
+    top of the document.
+  The LSP (v0.5.0+) honors both directives natively, so the diagnostic
+  disappears on the next publishDiagnostics round. Legacy native codes
+  (`ssl-*` kebab) skip these actions because the directives don't apply
+  to them.
+- **"Show docs for 'X'" code action.** When a diagnostic message names an
+  SSL element (function, class, etc.), the lightbulb offers a jump straight
+  to the corresponding ssl-docs page. The category is inferred from the
+  rule slug; if the inference can't be made the action is omitted rather
+  than shipping a broken link.
+
+### Tests
+- 4 new code-action unit tests covering line-scope suppress, file-scope
+  suppress, the legacy-code skip path, and the docs-link URL shape.
+
 ## [1.8.0] - 2026-04-30
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -93,6 +93,10 @@ code --install-extension vs-code-ssl-formatter-*.vsix
   - `default_after_parameters` — relocate `:DEFAULT` to follow `:PARAMETERS`.
   - `nested_iif` — refactor an `IIF(...)` assignment into `:IF / :ELSE / :ENDIF` (offered as a `Refactor → Rewrite` action).
   - Plus the legacy `ssl-invalid-direct-call` fix for native fallback.
+- **Universal lightbulb actions** offered alongside any rule-specific fix above:
+  - *Suppress '\<slug\>' on this line* — inserts `/* @ssl-disable-next-line <slug>; */`.
+  - *Suppress '\<slug\>' for this file* — inserts `/* @ssl-disable <slug>; */` at the top.
+  - *Show docs for '\<element\>'* — opens the ssl-docs page for the named function/class/keyword/operator.
 
 ### Editor Enhancements
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "type": "module",
     "displayName": "STARLIMS Scripting Language",
     "description": "Comprehensive language support for STARLIMS SSL: formatting, IntelliSense, diagnostics, and code quality tools",
-    "version": "1.8.0",
+    "version": "1.9.0",
     "engines": {
         "vscode": "^1.105.0"
     },

--- a/src/sslCodeActionProvider.ts
+++ b/src/sslCodeActionProvider.ts
@@ -1,4 +1,12 @@
 import * as vscode from 'vscode';
+import { SSL_DIAGNOSTIC_SLUGS } from './constants/diagnosticSlugs';
+
+/**
+ * Lowercase slug set for O(1) "is this an LSP rule slug?" checks. Used to
+ * gate the universal suppression / docs actions so they don't show up on
+ * non-LSP diagnostics (legacy native codes use a `ssl-` kebab prefix).
+ */
+const LSP_SLUG_SET = new Set<string>(SSL_DIAGNOSTIC_SLUGS as readonly string[]);
 
 /**
  * Quick-fix code actions for SSL diagnostics.
@@ -82,6 +90,23 @@ export class SSLCodeActionProvider implements vscode.CodeActionProvider {
 			}
 			if (action) {
 				actions.push(action);
+			}
+
+			// Universal helpers offered alongside any specific fix above:
+			// - Suppress this rule (line / file)
+			// - Open the rule's docs page
+			// Only for diagnostics whose code is a known LSP rule slug; we
+			// skip the legacy `ssl-*` native codes since the LSP-side
+			// suppression directives don't apply to them.
+			if (LSP_SLUG_SET.has(code)) {
+				actions.push(
+					createSuppressLineAction(document, diagnostic, code),
+					createSuppressFileAction(document, diagnostic, code),
+				);
+				const docsAction = createOpenDocsAction(document, diagnostic, code);
+				if (docsAction) {
+					actions.push(docsAction);
+				}
 			}
 		}
 
@@ -729,4 +754,138 @@ function splitTopLevelCommas(text: string): string[] {
 		result.push(buf);
 	}
 	return result;
+}
+
+// ---- universal: suppression comments ---------------------------------------
+
+/**
+ * Builds an SSL `@ssl-disable-next-line <slug>` directive comment, indented
+ * to match the diagnostic's line, and inserts it immediately above. The LSP
+ * v0.5.0+ honors the directive at parse time so the diagnostic disappears
+ * on the next publishDiagnostics round.
+ */
+function createSuppressLineAction(
+	document: vscode.TextDocument,
+	diagnostic: vscode.Diagnostic,
+	slug: string,
+): vscode.CodeAction {
+	const line = diagnostic.range.start.line;
+	const indent = leadingIndent(document, line);
+	const insertText = `${indent}/* @ssl-disable-next-line ${slug}; */\n`;
+
+	const fix = new vscode.CodeAction(
+		`Suppress '${slug}' on this line`,
+		vscode.CodeActionKind.QuickFix,
+	);
+	fix.edit = new vscode.WorkspaceEdit();
+	fix.edit.insert(document.uri, new vscode.Position(line, 0), insertText);
+	fix.diagnostics = [diagnostic];
+	fix.isPreferred = false;
+	return fix;
+}
+
+/**
+ * Builds a file-scope SSL `@ssl-disable <slug>` directive comment at the top
+ * of the document. We always insert at line 0 column 0 — placing it before
+ * any existing content keeps the directive's "applies to entire file"
+ * semantics unambiguous.
+ */
+function createSuppressFileAction(
+	document: vscode.TextDocument,
+	diagnostic: vscode.Diagnostic,
+	slug: string,
+): vscode.CodeAction {
+	const fix = new vscode.CodeAction(
+		`Suppress '${slug}' for this file`,
+		vscode.CodeActionKind.QuickFix,
+	);
+	fix.edit = new vscode.WorkspaceEdit();
+	fix.edit.insert(
+		document.uri,
+		new vscode.Position(0, 0),
+		`/* @ssl-disable ${slug}; */\n`,
+	);
+	fix.diagnostics = [diagnostic];
+	fix.isPreferred = false;
+	return fix;
+}
+
+function leadingIndent(document: vscode.TextDocument, line: number): string {
+	if (line < 0 || line >= document.lineCount) {
+		return '';
+	}
+	const text = document.lineAt(line).text;
+	const m = text.match(/^(\s*)/);
+	return m ? m[1] : '';
+}
+
+// ---- universal: open docs page ---------------------------------------------
+
+/**
+ * Some diagnostics name a specific element (e.g. "function 'X' has no
+ * documented support for named SQL parameters"). When we can pull a
+ * canonical SSL identifier out of the diagnostic message, offer to jump
+ * to the corresponding ssl-docs page.
+ *
+ * We don't try to infer element type from the message — the URL form
+ * /reference/<unknown>/<X> wouldn't work. Instead we use the rule slug
+ * as a hint about which category (functions, keywords, classes,
+ * operators) is most likely. If the heuristic doesn't match, we omit the
+ * action rather than offer a broken link.
+ */
+function createOpenDocsAction(
+	_document: vscode.TextDocument,
+	diagnostic: vscode.Diagnostic,
+	slug: string,
+): vscode.CodeAction | undefined {
+	const elementName = extractElementName(diagnostic.message);
+	if (!elementName) {
+		return undefined;
+	}
+	const category = inferCategoryFromSlug(slug);
+	if (!category) {
+		return undefined;
+	}
+
+	// ssl-docs URLs follow content/reference/<category>/<name>.md.
+	const url = `https://github.com/mahoskye/starlims-ssl-reference/blob/main/content/reference/${category}/${encodeURIComponent(elementName)}.md`;
+
+	const fix = new vscode.CodeAction(
+		`Show docs for '${elementName}'`,
+		vscode.CodeActionKind.QuickFix,
+	);
+	fix.command = {
+		title: fix.title,
+		command: 'vscode.open',
+		arguments: [vscode.Uri.parse(url)],
+	};
+	fix.diagnostics = [diagnostic];
+	// Suppress the empty-edit warning; this action only opens a URL.
+	fix.edit = undefined;
+	return fix;
+}
+
+const _MESSAGE_NAME_RE = /['"`]([A-Za-z_][A-Za-z0-9_]*)['"`]/;
+
+function extractElementName(message: string): string | undefined {
+	const m = message.match(_MESSAGE_NAME_RE);
+	return m ? m[1] : undefined;
+}
+
+function inferCategoryFromSlug(slug: string): string | undefined {
+	// Slug name fragments map to ssl-docs categories. Order matters — check
+	// the more specific fragments first.
+	if (slug.includes('class')) { return 'classes'; }
+	if (slug.includes('keyword')) { return 'keywords'; }
+	if (slug.includes('operator')) { return 'operators'; }
+	if (
+		slug.includes('function') ||
+		slug.includes('procedure') ||
+		slug.includes('execfunction') ||
+		slug.includes('sql_param') ||
+		slug.includes('udobject_array_in_clause')
+	) {
+		return 'functions';
+	}
+	return undefined;
 }

--- a/tests/code_action.test.ts
+++ b/tests/code_action.test.ts
@@ -341,6 +341,68 @@ describe('Code Actions: v1.7.0 additions', () => {
         assert.strictEqual(defaultIdx, paramsIdx + 1, ':DEFAULT should be directly after :PARAMETERS');
     });
 
+    it('universal: suppress on this line inserts @ssl-disable-next-line', async function () {
+        const doc = await openDoc(`:PROCEDURE T;\n\tnLocal := 1;\n:ENDPROC;\n`);
+        const range = new vscode.Range(1, 1, 1, 7);
+        const diag = diagnostic(range, "synthetic", 'parameters_first');
+
+        const provider = new SSLCodeActionProvider();
+        const actions = provider.provideCodeActions(doc, range, context(diag), {} as vscode.CancellationToken);
+        const fix = actions.find(a => a.title.startsWith("Suppress 'parameters_first' on this line"));
+        assert.ok(fix, 'expected line-suppress action');
+        await vscode.workspace.applyEdit(fix.edit!);
+        const text = doc.getText();
+        // The directive should be inserted on its own line above the diagnostic line.
+        assert.ok(text.includes('@ssl-disable-next-line parameters_first'),
+            `expected directive in document, got:\n${text}`);
+    });
+
+    it('universal: suppress for this file inserts @ssl-disable at top', async function () {
+        const doc = await openDoc(`:PROCEDURE T;\n\tnLocal := 1;\n:ENDPROC;\n`);
+        const range = new vscode.Range(1, 1, 1, 7);
+        const diag = diagnostic(range, "synthetic", 'keyword_uppercase');
+
+        const provider = new SSLCodeActionProvider();
+        const actions = provider.provideCodeActions(doc, range, context(diag), {} as vscode.CancellationToken);
+        const fix = actions.find(a => a.title.startsWith("Suppress 'keyword_uppercase' for this file"));
+        assert.ok(fix, 'expected file-suppress action');
+        await vscode.workspace.applyEdit(fix.edit!);
+        assert.ok(doc.getText().startsWith('/* @ssl-disable keyword_uppercase'),
+            `expected directive at top, got:\n${doc.getText()}`);
+    });
+
+    it('universal: suppress actions only appear for known LSP slugs', async function () {
+        const doc = await openDoc(`:PROCEDURE T;\n\tnLocal := 1;\n:ENDPROC;\n`);
+        const range = new vscode.Range(1, 1, 1, 7);
+        // Native code with kebab prefix — should NOT get the universal suppress actions.
+        const diag = diagnostic(range, "synthetic", 'ssl-invalid-direct-call');
+
+        const provider = new SSLCodeActionProvider();
+        const actions = provider.provideCodeActions(doc, range, context(diag), {} as vscode.CancellationToken);
+        assert.strictEqual(
+            actions.find(a => a.title.includes('Suppress')),
+            undefined,
+            'universal suppress should not be offered for legacy native codes',
+        );
+    });
+
+    it('universal: open docs action targets ssl-docs URL when message names an element', async function () {
+        const doc = await openDoc(`:PROCEDURE T;\n\tDoProc("X", {});\n:ENDPROC;\n`);
+        const range = new vscode.Range(1, 1, 1, 7);
+        // direct_procedure_call is in the slug list; the heuristic infers
+        // category=functions from the "procedure_call" fragment.
+        const diag = diagnostic(range, "Custom procedure 'X' must be invoked via DoProc", 'direct_procedure_call');
+
+        const provider = new SSLCodeActionProvider();
+        const actions = provider.provideCodeActions(doc, range, context(diag), {} as vscode.CancellationToken);
+        const fix = actions.find(a => a.title.startsWith("Show docs for 'X'"));
+        assert.ok(fix, `expected docs link action; got titles: ${actions.map(a => a.title).join(', ')}`);
+        assert.strictEqual(fix.command?.command, 'vscode.open');
+        const target = (fix.command?.arguments?.[0] as vscode.Uri).toString();
+        assert.ok(target.includes('content/reference/functions/X.md'),
+            `expected docs URL, got: ${target}`);
+    });
+
     it('nested_iif: rewrites assignment-form IIF into :IF/:ELSE block', async function () {
         const doc = await openDoc(`:PROCEDURE T;\n\tx := IIF(c, a, b);\n:ENDPROC;\n`);
         const lineText = doc.lineAt(1).text;

--- a/tests/helpers/mockVSCode.ts
+++ b/tests/helpers/mockVSCode.ts
@@ -96,6 +96,10 @@ export class MockUri {
 		return new MockUri(path);
 	}
 
+	static parse(value: string): MockUri {
+		return new MockUri(value);
+	}
+
 	toString(): string {
 		return this.fsPath;
 	}


### PR DESCRIPTION
## Summary
Closes the remaining items from the v1.7.0 \"what remains\" triage.

For any LSP-emitted diagnostic with a known rule slug, three new lightbulb actions:
- **Suppress '\<slug\>' on this line** — inserts \`@ssl-disable-next-line <slug>\` directive comment above
- **Suppress '\<slug\>' for this file** — inserts \`@ssl-disable <slug>\` directive at the top
- **Show docs for '\<element\>'** — opens the ssl-docs page for the named function / class / keyword

The LSP v0.5.0+ honors both suppression directives natively. Legacy native codes (kebab-prefixed \`ssl-*\`) skip the suppress actions since the directives don't apply to them.

The earlier deferred item *"route exception messages into diagnostic text on the LSP side"* is closed as superseded — hover and the docs-link action already cover that surface, and routing exception text into individual diagnostic messages would duplicate it.

## Test plan
- [x] \`npm run compile\` clean with strict checks on
- [x] \`npm run test:unit\` — 308 passing (was 304)
- [ ] CI green
- [ ] Manual: trigger a rule, verify all three new lightbulb entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)