### PR TITLE
Replace coactions/setup-xvfb with plain xvfb-run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,10 +42,15 @@ jobs:
     - name: Run unit tests
       run: npm run test:unit
 
-    - name: Run integration tests
-      uses: coactions/setup-xvfb@b6b4fcfb9f5a895edadc3bc76318fae0ac17c8b3 # v1
-      with:
-        run: npm run test:integration
+    - name: Run integration tests (Linux, under xvfb)
+      if: runner.os == 'Linux'
+      run: |
+        sudo apt-get update -qq && sudo apt-get install -y -qq xvfb
+        xvfb-run --auto-servernum npm run test:integration
+
+    - name: Run integration tests (macOS/Windows)
+      if: runner.os != 'Linux'
+      run: npm run test:integration
 
     - name: Check for console.log in production code
       if: runner.os == 'Linux'
@@ -89,9 +94,9 @@ jobs:
       run: node scripts/package-platforms.mjs
 
     - name: Smoke-test the linux-x64 package
-      uses: coactions/setup-xvfb@b6b4fcfb9f5a895edadc3bc76318fae0ac17c8b3 # v1
-      with:
-        run: node scripts/smoke-vsix.mjs linux-x64
+      run: |
+        sudo apt-get update -qq && sudo apt-get install -y -qq xvfb
+        xvfb-run --auto-servernum node scripts/smoke-vsix.mjs linux-x64
 
     - name: Upload VSIX artifacts
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -48,9 +48,9 @@ jobs:
       run: node scripts/package-platforms.mjs
 
     - name: Smoke-test the linux-x64 package
-      uses: coactions/setup-xvfb@b6b4fcfb9f5a895edadc3bc76318fae0ac17c8b3 # v1
-      with:
-        run: node scripts/smoke-vsix.mjs linux-x64
+      run: |
+        sudo apt-get update -qq && sudo apt-get install -y -qq xvfb
+        xvfb-run --auto-servernum node scripts/smoke-vsix.mjs linux-x64
 
     - name: Publish tested packages to VS Code Marketplace
       if: github.event_name == 'release'


### PR DESCRIPTION
## Summary
GitHub's runners warn that `coactions/setup-xvfb` targets the deprecated Node 20 action runtime. This drops the action in favor of installing `xvfb` via apt and calling `xvfb-run --auto-servernum` directly, in all three places it was used (CI integration tests, CI package smoke test, publish smoke test). Integration tests split into a Linux step (under xvfb) and a macOS/Windows step, preserving prior behavior.

Side benefit: the workflows now use only GitHub-owned actions, all SHA-pinned.

## Validation
- CI on this PR exercises both changed paths directly (integration tests on all three OSes + the package-job smoke test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)