### PR TITLE
Bump actions/upload-artifact to v7.0.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,7 @@ jobs:
         xvfb-run --auto-servernum node scripts/smoke-vsix.mjs linux-x64
 
     - name: Upload VSIX artifacts
-      uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: ssl-extension-${{ github.sha }}
         path: 'dist-vsix/*.vsix'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -60,7 +60,7 @@ jobs:
 
     - name: Upload VSIX artifacts (manual dispatch)
       if: github.event_name == 'workflow_dispatch'
-      uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: ssl-extension-manual
         path: 'dist-vsix/*.vsix'


### PR DESCRIPTION
## Summary
Bumps the SHA-pinned `actions/upload-artifact` from a v5 commit (which targets the deprecated Node 20 action runtime — the last remaining deprecation warning in CI) to v7.0.1. The inputs this repo uses (`name`, `path`, `retention-days`) are unchanged across versions.

## Validation
- The package job on this PR uploads the vsix artifacts through the new version directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)